### PR TITLE
Add modal window to landing page

### DIFF
--- a/landingpage.php
+++ b/landingpage.php
@@ -18,6 +18,7 @@ License: A "Slug" license name e.g. GPL2
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Ergo Saddle</title>
 	<link rel="stylesheet" href="css/style.css">
+    <script src="js/main.js"></script>
 </head>
 <body>
 <div class="page-container">
@@ -44,16 +45,27 @@ License: A "Slug" license name e.g. GPL2
 				<p>Discover the perfect balance of support and mobility with our innovative saddlechair...</p>
 				<div class="cta-buttons">
 					<a href="#contact" class="btn btn-primary">Get Your Free Trial</a>
-					<a href="#features" class="btn btn-secondary">Learn More</a>
+					<a id="learnMoreBtn" href="#features" class="btn btn-secondary">Learn More</a>
 				</div>
 			</div>
 			<img src="/placeholder.svg" alt="Ergonomic Saddlechair" class="hero-img">
 		</section>
 
+        <!-- Modal -->
+        <div class="modal-overlay" id="modalOverlay"></div>
+        <div class="modal" id="modal">
+            <div class="modal-header">More Information</div>
+            <div class="modal-body">
+                Here is detailed information about the product. This text can be customized as needed.
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-close" id="closeModalBtn">Close</button>
+            </div>
+        </div>
+
 		<section id="features" class="features">
 			<h2 class="hero-subheader">Features Designed for Your Comfort</h2>
 			<div class="feature-list">
-				<div class="feature-item">
 					<div class="icon-circle"><svg
                                 class="h-6 w-6 text-white"
                                 fill="none"


### PR DESCRIPTION
Add modal window functionality to the landing page for ergonomic chairs.

* Add modal window HTML structure after the hero section in `landingpage.php`.
* Add `id="learnMoreBtn"` to the "Learn More" button in `landingpage.php`.
* Add `id="modalOverlay"` and `id="modal"` to the modal overlay and modal divs in `landingpage.php`.
* Include `js/main.js` script in the head section of `landingpage.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stove/SD-landingpages/pull/1?shareId=9d7f8b5e-9fcd-4408-81f1-2886e19b056c).